### PR TITLE
Move Spitting Ant Tower calls to projectile handler

### DIFF
--- a/Assets/Tower/SpittingAntTower.cs
+++ b/Assets/Tower/SpittingAntTower.cs
@@ -175,9 +175,7 @@ public class SpittingAntTower : Tower {
       upperMesh.LookAt(projectileHandler.GetSafeChildPosition(enemy.transform));
       firing = true;
 
-      if (!ContinuousAttack) {
-        projectileHandler.UpdateParticles(enemy, ProcessDamageAndEffects);
-      } else {
+      if (ContinuousAttack) {
         beam.enabled = true;
         beam.SetPosition(
             1,  // The destination of the system.
@@ -185,6 +183,10 @@ public class SpittingAntTower : Tower {
 
         ProcessDamageAndEffects(enemy);
       }
+    }
+
+    if (!ContinuousAttack) {
+      projectileHandler.UpdateParticles(enemy, ProcessDamageAndEffects);
     }
   }
 


### PR DESCRIPTION
Should resolve a potential bug about projectiles hanging when an enemy moves out of range of a spitting ant tower.