### PR TITLE
Fix all warnings in the project.

### DIFF
--- a/Assets/GameManager/CameraManager.cs
+++ b/Assets/GameManager/CameraManager.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -8,7 +5,7 @@ using UnityEngine;
 public class CameraManager : MonoBehaviour {
   public static CameraManager Instance;
 
-  private Camera camera;
+  new private Camera camera;
   // This is how much padding, in world space, we give to the map.
   // This value was made up whole cloth without much thought, but it doesn't look bad.
   private float screenOffset = 20;

--- a/Assets/GameManager/GameStateManager.cs
+++ b/Assets/GameManager/GameStateManager.cs
@@ -6,9 +6,9 @@ using UnityEngine;
 
 // This class is a catch-all for gamestate management that doesn't have a better home elsewhere.
 public class GameStateManager : MonoBehaviour {
-  public static GameStateManager Instance;
-  public static event Action GameOver;
-  public static event Action<int> HealthChanged;
+  public static GameStateManager Instance = new();
+  public static event Action GameOver = delegate { };
+  public static event Action<int> HealthChanged = delegate { };
   // The type of tower currently selected by the user for construction.
   public static GameObject? SelectedTowerType;
 
@@ -43,6 +43,7 @@ public class GameStateManager : MonoBehaviour {
     if (Health <= 0) GameOver?.Invoke();
   }
 
+  // Add a tower to the active tower tracking map.
   public void AddTower(Vector2Int coordinates, Tower tower) {
     activeTowerMap.Add(coordinates, tower);
   }

--- a/Assets/Spawner/ObjectPool.cs
+++ b/Assets/Spawner/ObjectPool.cs
@@ -4,14 +4,14 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class ObjectPool : MonoBehaviour {
-  static public ObjectPool Instance;
+  static public ObjectPool Instance = new();
 
   // An ugly artifact, just a pair class.
   // [TODO: nnewsom] get rid of this with Addressables or a SerializableDictionary.
   [Serializable]
   public class EnemyEntry {
     [SerializeField] public EnemyData.Type type;
-    [SerializeField] public GameObject prefab;
+    [SerializeField] public GameObject prefab = new();
   }
 
   [SerializeField] private int startingSize = 20;

--- a/Assets/Spawner/Spawner.cs
+++ b/Assets/Spawner/Spawner.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Xml.Serialization;
 using UnityEngine;
@@ -10,8 +9,8 @@ using UnityEngine;
 using static EpicBeardLib.XmlSerializationHelpers;
 
 public class Spawner : MonoBehaviour {
-  public static event Action OnLevelComplete;
-  static public Spawner Instance;
+  public static event Action OnLevelComplete = delegate { };
+  static public Spawner Instance = new();
 
   [SerializeField] private List<Waypoint> spawnLocations = new();
   [SerializeField] private string filename = "";

--- a/Assets/Tower/TowerData.cs
+++ b/Assets/Tower/TowerData.cs
@@ -45,6 +45,10 @@ public struct TowerData {
       return false;
     }
 
+    public override int GetHashCode() {
+      return Tuple.Create(first, second, third).GetHashCode();
+    }
+
     public override string ToString() {
       return "\n"
           + "first upgrade path name: " + first + "\n"


### PR DESCRIPTION
Resolves warnings about:
- Not overriding GetHashCode when Equals was overwritten.
- Instance variables possibly having a null value (empty initialization).
- Event methods not having an initial value.
- Class members obscuring unrelated entities.