### PR TITLE
fix the crash on new games where the 'saves' directory doesn't exist

### DIFF
--- a/Assets/GameManager/SaveManager.cs
+++ b/Assets/GameManager/SaveManager.cs
@@ -39,6 +39,8 @@ public class SaveManager : MonoBehaviour {
     state.lastSavedTime = DateTimeOffset.Now.ToUnixTimeMilliseconds();
     string fileName = state.SaveName + state.Id + ".sav";
     string saveFile = Path.Combine(SaveLocation, fileName);
+    var dir = Path.GetDirectoryName(saveFile);
+    Directory.CreateDirectory(dir);
     Serialize<PlayerState>(state, saveFile);
   }
 }


### PR DESCRIPTION
This was throwing a directory not found exception and not loading past the start screen. Directory.createDirectory() checks if the directory exists before creating it so it works on first save and subsequent saves.