### PR TITLE
Hide message box by default

### DIFF
--- a/Assets/Resources/UI/Components/MessageBox/MessageBox.uss
+++ b/Assets/Resources/UI/Components/MessageBox/MessageBox.uss
@@ -1,4 +1,6 @@
 .message-box {
+    display: none;
+
     flex-grow: 1;
     flex-shrink: 1;
     justify-content: space-between;


### PR DESCRIPTION
This fixes an issue where the message box was showing on every scene even if there was no text and no way to close it. Now it doesn't show up on the dev scenes anymore.