### PR TITLE
fix tower upgrade states

### DIFF
--- a/Assets/Resources/UI/Screens/Terrarium/ContextPanel/TowerDetail.cs
+++ b/Assets/Resources/UI/Screens/Terrarium/ContextPanel/TowerDetail.cs
@@ -139,34 +139,40 @@ public class TowerDetail : MonoBehaviour {
   private void HandleTowerUpgradeCallback(ClickEvent evt) {
     Button rockerSwitch = Utilities.GetAncestor<Button>(evt.target as VisualElement);
     if (rockerSwitch == null) return;
-    if (rockerSwitch.ClassListContains("rocker-switch-on")) return;
 
     ButtonWithTooltip icon = rootElement.Q<ButtonWithTooltip>(rockerSwitch.name);
     if (icon == null) return;
+
+    Tower tower = TowerManager.SelectedTower;
+    if (tower == null) return;
 
     // tree_X_upgrade_Y__button
     // 0____5_________15
     int upgradePath = (int)Char.GetNumericValue(rockerSwitch.name[5]);
     int upgradeNum = (int)Char.GetNumericValue(rockerSwitch.name[15]);
 
-    // check that previous upgrade is owned
-    if (upgradeNum > 0 && towerUpgradeSwitches[upgradePath, upgradeNum - 1].ClassListContains("rocker-switch-off")) {
+    // check that current upgrade is not already owned
+    if (tower.UpgradeLevels[upgradePath] == upgradeNum) {
         return;
     }
 
-    TowerAbility upgrade = TowerManager.SelectedTower.GetUpgradePath(upgradePath)[upgradeNum];
+    // check that previous upgrade is owned
+    if (tower.UpgradeLevels[upgradePath] != upgradeNum - 1) {
+        return;
+    }
 
+    // check that player can afford the upgrade
+    TowerAbility upgrade = tower.GetUpgradePath(upgradePath)[upgradeNum];
     if (GameStateManager.Instance.Nu < upgrade.cost) {
       return;
     }
 
-    rockerSwitch.AddToClassList("rocker-switch-on");
-    rockerSwitch.RemoveFromClassList("rocker-switch-off");
-
+    // all checks passed, continue with upgrade
+    SetRockerSwitchState(rockerSwitch, true);
     GameStateManager.Instance.Nu -= upgrade.cost;
-    TowerManager.SelectedTower.Upgrade(upgrade);
+    tower.Upgrade(upgrade);
 
-    SetContextForTower(TowerManager.SelectedTower);
+    SetContextForTower(tower);
   }
 
   private void OnSellTowerClick(ClickEvent evt) {
@@ -222,13 +228,25 @@ public class TowerDetail : MonoBehaviour {
     for (int i = 0; i < 3; i++) {
       string upgradePathName = tower.GetUpgradePathName(i);
       towerUpgradeTreeLabels[i].text = upgradePathName;
-
     for (int j = 0; j < 5; j++) {
+        bool isOwned = j <= tower.UpgradeLevels[i];
+        SetRockerSwitchState(towerUpgradeSwitches[i, j], isOwned);
+
         towerUpgradeIcons[i, j].TooltipText = tower.GetUpgradePath(i)[j].description;
         string imgPath = "UI/images/tower upgrades/" + tower.Name + "/" + upgradePathName.ToLower() + " " + j;
         towerUpgradeIcons[i, j].style.backgroundImage = Resources.Load<Texture2D>(imgPath);
       }
     }
+  }
+
+  private void SetRockerSwitchState(Button rockerSwitch, bool isOn) {
+      if (isOn) {
+          rockerSwitch.AddToClassList("rocker-switch-on");
+          rockerSwitch.RemoveFromClassList("rocker-switch-off");
+      } else {
+          rockerSwitch.AddToClassList("rocker-switch-off");
+          rockerSwitch.RemoveFromClassList("rocker-switch-on");
+      }
   }
 
   public void SetContextTowerName(string name) {

--- a/Assets/Tower/Tower.cs
+++ b/Assets/Tower/Tower.cs
@@ -123,7 +123,7 @@ public abstract class Tower : MonoBehaviour {
   public string IconPath { get { return data.icon_path; } set { data.icon_path = value; } }
   #endregion
 
-  protected int[] upgradeLevels = new int[] { 0, 0, 0 };  // Each entry in this array should be 0-4.
+  protected int[] upgradeLevels = new int[] { -1, -1, -1 };  // Each entry in this array should be -1-4.
   public int[] UpgradeLevels { get { return upgradeLevels; } }
 
   // How close a particle needs to get to consider it a hit.


### PR DESCRIPTION
This change fixes a bug that broke the switches on the tower upgrades. Now the tower contextUI updates using tower.UpgradeLevels to get the correct tower upgrade state. This is then translated to the UI when setting the tower context and when purchasing any upgrades.

Previously the rocker switches were only set once so any time an upgrade was purchased the rocker switch remained in the on state forever even after selling a tower or constructing a completely different tower type.

Note: The tower upgrade levels were previously set to initialize at 0. However this means that upgrade 0, the first upgrade, isn't distinguishable from having no upgrades purchased. This change sets the upgrade levels to initialize at -1 so that there is a distinction between those two states.

### ✔ All tests passing ✔