### PR TITLE
add body font to message box and tooltip

### DIFF
--- a/Assets/Resources/UI/Components/MessageBox/MessageBox.uss
+++ b/Assets/Resources/UI/Components/MessageBox/MessageBox.uss
@@ -14,6 +14,11 @@
     border-width: 1px;
 }
 
+.message-box-text {
+    font-size: 22px;
+    -unity-font-definition: url("/Assets/Font/TruetypewriterPolyglott-mELa SDF.asset");
+}
+
 .message-box > .tertiary-button {
     align-self: center;
 }

--- a/Assets/Resources/UI/Components/MessageBox/MessageBox.uxml
+++ b/Assets/Resources/UI/Components/MessageBox/MessageBox.uxml
@@ -3,7 +3,7 @@
     <Style src="project://database/Assets/Resources/UI/Components/MessageBox/MessageBox.uss?fileID=7433441132597879392&amp;guid=15a05e0f75642a94a99f54184bb69fd0&amp;type=3#MessageBox" />
     
     <ui:VisualElement name="message-box-container" class="message-box">
-        <ui:Label name="message-box-label" tabindex="-1" picking-mode="Ignore" />
+        <ui:Label name="message-box-label" class="message-box-text" tabindex="-1" picking-mode="Ignore" />
         <ui:Button name="message-box-button" class="button-base tertiary-button" enable-rich-text="true" />
     </ui:VisualElement>
 </ui:UXML>

--- a/Assets/Resources/UI/Screens/Terrarium/TerrariumScreen.uss
+++ b/Assets/Resources/UI/Screens/Terrarium/TerrariumScreen.uss
@@ -18,13 +18,13 @@
 .message-box-parent {
   position: absolute;
   bottom: 80px;
-  left: 100px;
+  left: 30px;
   flex-grow: 0;
   flex-direction: row;
   justify-content: space-between;
   align-items: stretch;
   align-self: stretch;
-  width: 700px;
+  width: 840px;
   min-width: auto;
   min-height: auto;
   background-color: rgba(0, 0, 0, 0);
@@ -84,7 +84,7 @@
   -unity-background-image-tint-color: #777777;
 }
 
-.tooltip-container{
+.tooltip-container {
   position: absolute;
   display: none;
   left: auto;
@@ -98,6 +98,8 @@
    padding: 4px;
    color: #ffffff;
    background-color: rgba(0, 0, 0, 0.75);
+   font-size: 18px;
+   -unity-font-definition: url("/Assets/Font/TruetypewriterPolyglott-mELa SDF.asset");
    overflow: hidden;
    visibility: visible;
    white-space: normal;


### PR DESCRIPTION
Adds typewriter font to message box and tooltip.

### ✔ All tests passing ✔

### Screenshots
message box
<img width="679" alt="message box" src="https://github.com/epic-beard/insect-defense/assets/11901499/eb06b577-2781-4ce9-8456-c18a8841fc2b">

tooltip
<img width="332" alt="tooltip" src="https://github.com/epic-beard/insect-defense/assets/11901499/5d2aeb62-ce05-4ed9-b5da-1f6d232ace94">
