### PR TITLE
Preliminary Work for Selling Upgrades

### DIFF
--- a/Assets/Resources/UI/Screens/Terrarium/ContextPanel/TowerDetail.cs
+++ b/Assets/Resources/UI/Screens/Terrarium/ContextPanel/TowerDetail.cs
@@ -197,24 +197,30 @@ public class TowerDetail : MonoBehaviour {
   private void SellUpgrades(Tower tower, int  upgradePath, int upgradeNum) {
     UiSfx.PlaySfx(UiSfx.rocker_switch);
 
-    while (tower.UpgradeLevels[upgradePath] >= upgradeNum) {
-      TowerAbility upgrade = tower.GetUpgradePath(upgradePath)[upgradeNum];
+    int level = tower.UpgradeIndex[upgradePath];
+    while (level >= upgradeNum) {
+      TowerAbility upgrade = tower.GetUpgradePath(upgradePath)[level];
       GameStateManager.Instance.Nu += upgrade.cost;
-      Button rockerSwitch = towerUpgradeSwitches[upgradePath, upgradeNum];
+      Button rockerSwitch = towerUpgradeSwitches[upgradePath, level];
       SetRockerSwitchState(rockerSwitch, false);
-      tower.UpgradeLevels[upgradePath]--;
+      level--;
     }
-    List<int> levels = tower.UpgradeLevels.ToList();
+
+    List<int> levels = tower.UpgradeIndex.ToList();
+    levels[upgradePath] = level;
     tower.SetTowerData(TowerManager.Instance.GetTowerData(tower.Type));
-    
-    for (int i = 0; i < 3; i++) {
-      while (tower.UpgradeLevels[i] < levels[i]) {
-        tower.UpgradeLevels[i]++;
-        TowerAbility upgrade = tower.GetUpgradePath(i)[tower.UpgradeLevels[i]];
+    tower.ResetTransientState();
+
+    for (int path = 0; path < 3; path++) {
+      level = -1;
+      while (level < levels[path]) {
+        level++;
+        TowerAbility upgrade = tower.GetUpgradePath(path)[level];
         tower.Upgrade(upgrade);
       }
     }
-    
+
+    SetContextForTower(tower);
   }
 
   private void OnSellTowerClick(ClickEvent evt) {

--- a/Assets/Tower/Tower.cs
+++ b/Assets/Tower/Tower.cs
@@ -264,6 +264,17 @@ public abstract class Tower : MonoBehaviour {
     }
   }
 
+  public void ResetTransientState() {
+    SlimePower = 1.0f;
+    SlimeTime = Time.time;
+
+    DazzleTime = Time.time;
+
+    BaseAttackSpeed = 0;
+    Target = null;
+    upgradeIndex = new int[] { -1, -1, -1 };
+  }
+
   private IEnumerator HandleDazzle() {
     float time = Time.time;
     while (DazzleTime > time) {

--- a/Assets/Tower/Tower.cs
+++ b/Assets/Tower/Tower.cs
@@ -29,7 +29,6 @@ public abstract class Tower : MonoBehaviour {
     get { return data[TowerData.Stat.ARMOR_TEAR]; }
     set { data[TowerData.Stat.ARMOR_TEAR] = value; }
   }
-
   public float BaseAttackSpeed { get; private set; }
   public float Cost {
     get { return data[TowerData.Stat.COST]; }
@@ -238,7 +237,7 @@ public abstract class Tower : MonoBehaviour {
 
   public void SetTowerData(TowerData data) {
     this.data = data;
-   
+    BaseAttackSpeed = data[TowerData.Stat.ATTACK_SPEED];
   }
 
   public void CacheTowerRenderers() {
@@ -263,17 +262,6 @@ public abstract class Tower : MonoBehaviour {
       DazzleTime = time;
       StartCoroutine(HandleDazzle());
     }
-  }
-
-  public void ResetTransientState() {
-    SlimePower = 1.0f;
-    SlimeTime = Time.time;
-
-    DazzleTime = Time.time;
-
-    BaseAttackSpeed = 0;
-    Target = null;
-    upgradeIndex = new int[] { -1, -1, -1 };
   }
 
   private IEnumerator HandleDazzle() {

--- a/Assets/Tower/Tower.cs
+++ b/Assets/Tower/Tower.cs
@@ -29,6 +29,7 @@ public abstract class Tower : MonoBehaviour {
     get { return data[TowerData.Stat.ARMOR_TEAR]; }
     set { data[TowerData.Stat.ARMOR_TEAR] = value; }
   }
+
   public float BaseAttackSpeed { get; private set; }
   public float Cost {
     get { return data[TowerData.Stat.COST]; }
@@ -237,7 +238,7 @@ public abstract class Tower : MonoBehaviour {
 
   public void SetTowerData(TowerData data) {
     this.data = data;
-    BaseAttackSpeed = data[TowerData.Stat.ATTACK_SPEED];
+   
   }
 
   public void CacheTowerRenderers() {
@@ -262,6 +263,17 @@ public abstract class Tower : MonoBehaviour {
       DazzleTime = time;
       StartCoroutine(HandleDazzle());
     }
+  }
+
+  public void ResetTransientState() {
+    SlimePower = 1.0f;
+    SlimeTime = Time.time;
+
+    DazzleTime = Time.time;
+
+    BaseAttackSpeed = 0;
+    Target = null;
+    upgradeIndex = new int[] { -1, -1, -1 };
   }
 
   private IEnumerator HandleDazzle() {

--- a/PlayModeTests.csproj
+++ b/PlayModeTests.csproj
@@ -9,7 +9,7 @@
     <ProductVersion>10.0.20506</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <RootNamespace></RootNamespace>
-    <ProjectGuid>{6504BDF0-5EEB-747E-D2AA-FDC813127D30}</ProjectGuid>
+    <ProjectGuid>{E0154A8A-4FFA-D768-7077-19D64B0D0043}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>PlayModeTests</AssemblyName>
@@ -704,11 +704,11 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="Code.csproj">
-      <Project>{346AE815-C61F-1345-B9B9-B6B0397F17FA}</Project>
+      <Project>{2BCE259E-72D6-F83B-080F-37F2F33D4F15}</Project>
       <Name>Code</Name>
     </ProjectReference>
     <ProjectReference Include="Tests.csproj">
-      <Project>{65F69217-C3DE-8451-F960-F005B277DBED}</Project>
+      <Project>{AF493EF0-6097-FFCE-D14C-D4621A4AE48E}</Project>
       <Name>Tests</Name>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
Introduces Upgrade Selling
Ideologically this is just a QoL improvement to simplify selling and buying the same type of tower.
You can sell an upgrade by clicking on the toggle a second time.
If you sell further down the upgrade path you can sell multiple upgrades at once.

Left to do:
Add popup guarding selling
Deactivate the tower for a short time after selling
Allow unlimited selling while deactivated

All Tests Pass