### PR TITLE
Delay the selling of upgrades

### DIFF
--- a/Assets/GameManager/TowerManager.cs
+++ b/Assets/GameManager/TowerManager.cs
@@ -90,25 +90,27 @@ public class TowerManager : MonoBehaviour {
   public bool BuildTower(Waypoint waypoint) {
     if (SelectedTowerType == null) { return false; }
 
-    TowerData data = GetTowerData(SelectedTowerType??TowerData.Type.NONE);
+    TowerData data = GetTowerData(SelectedTowerType ?? TowerData.Type.NONE);
     int cost = GetTowerCost(data);
     if (GameStateManager.Instance.Nu < cost) { return false; }
     GameStateManager.Instance.Nu -= cost;
     AddTowerPrice(data.type, cost);
     Tower tower = ConstructTower(waypoint, data);
-    StartCoroutine(DisableTower(tower, buildDelay, () => {
-      MakeTowerOpaque(tower);
-      tower.enabled = true;
-    }));
+    StartCoroutine(DisableTower(tower, buildDelay,
+        () => {
+          MakeTowerOpaque(tower);
+          tower.enabled = true;
+        }));
     return true;
   }
 
   public void DisableTowerAfterSellingUpgrade(Tower tower) {
-    StartCoroutine(DisableTower(tower, buildDelay + sellDelay, () => {
-      MakeTowerOpaque(tower);
-      tower.enabled = true;
-      tower.IsMutatingUpgrades = false;
-    }));
+    StartCoroutine(DisableTower(tower, buildDelay + sellDelay,
+        () => {
+          MakeTowerOpaque(tower);
+          tower.enabled = true;
+          tower.IsMutatingUpgrades = false;
+        }));
   }
 
   // Refund the tower's full cost (including upgrades) and remove the tower from the map.
@@ -118,9 +120,10 @@ public class TowerManager : MonoBehaviour {
     int cost = tower.Value;
     TowerPrices[tower.Type].Pop();
     GameStateManager.Instance.Nu += cost;
-    StartCoroutine(DisableTower(tower, sellDelay, () => {
-      Destroy(tower.gameObject);
-    }));
+    StartCoroutine(DisableTower(tower, sellDelay,
+        () => {
+          Destroy(tower.gameObject);
+        }));
     ClearSelection();
   }
 

--- a/Assets/GameManager/TowerManager.cs
+++ b/Assets/GameManager/TowerManager.cs
@@ -95,16 +95,40 @@ public class TowerManager : MonoBehaviour {
     if (GameStateManager.Instance.Nu < cost) { return false; }
     GameStateManager.Instance.Nu -= cost;
     AddTowerPrice(data.type, cost);
-    StartCoroutine(BuildTower(waypoint, data));
+    Tower tower = ConstructTower(waypoint, data);
+    StartCoroutine(DisableTower(tower, buildDelay, () => {
+      MakeTowerOpaque(tower);
+      tower.enabled = true;
+    }));
     return true;
   }
 
-  public IEnumerator BuildTower(Waypoint waypoint, TowerData data) {
-    Tower tower = ConstructTower(waypoint, data);
+  public void DisableTowerAfterSellingUpgrade(Tower tower) {
+    StartCoroutine(DisableTower(tower, buildDelay + sellDelay, () => {
+      MakeTowerOpaque(tower);
+      tower.enabled = true;
+      tower.IsMutatingUpgrades = false;
+    }));
+  }
+
+  // Refund the tower's full cost (including upgrades) and remove the tower from the map.
+  public void RefundTower(Tower tower) {
+    if (tower == null) return;
+    ActiveTowerMap.Remove(tower.Tile.GetCoordinates());
+    int cost = tower.Value;
+    TowerPrices[tower.Type].Pop();
+    GameStateManager.Instance.Nu += cost;
+    StartCoroutine(DisableTower(tower, sellDelay, () => {
+      Destroy(tower.gameObject);
+    }));
+    ClearSelection();
+  }
+
+  private IEnumerator DisableTower(Tower tower, float duration, Action continuation) {
+    tower.enabled = false;
     MakeTowerTransluscent(tower, buildSellTransparency);
-    yield return new WaitForSeconds(buildDelay);
-    MakeTowerOpaque(tower);
-    tower.enabled = true;
+    yield return new WaitForSeconds(duration);
+    continuation();
   }
 
   public List<Tower> GetTowersInRange(float range, Vector3 pos) {
@@ -137,24 +161,6 @@ public class TowerManager : MonoBehaviour {
 
   public void RefundSelectedTower() {
     RefundTower(SelectedTower);
-  }
-
-  // Refund the tower's full cost (including upgrades) and remove the tower from the map.
-  public void RefundTower(Tower tower) {
-    if (tower == null) return;
-    ActiveTowerMap.Remove(tower.Tile.GetCoordinates());
-    MakeTowerTransluscent(tower, buildSellTransparency);
-    StartCoroutine(DestroyTower(tower));
-    ClearSelection();
-  }
-
-  private IEnumerator DestroyTower(Tower tower) {
-    tower.enabled = false;
-    yield return new WaitForSeconds(sellDelay);
-    Destroy(tower.gameObject);
-    int cost = tower.Value;
-    TowerPrices[tower.Type].Pop();
-    GameStateManager.Instance.Nu += cost;
   }
 
   public void SetSelectedTowerType(TowerData.Type type) {

--- a/Assets/Resources/UI/Screens/Terrarium/ContextPanel/TowerDetail.cs
+++ b/Assets/Resources/UI/Screens/Terrarium/ContextPanel/TowerDetail.cs
@@ -165,6 +165,10 @@ public class TowerDetail : MonoBehaviour {
     // check that current upgrade is not already owned
     if (tower.UpgradeIndex[upgradePath] >= upgradeNum) {
       SellUpgrades(tower, upgradePath, upgradeNum);
+      if (!tower.IsMutatingUpgrades) {
+        tower.IsMutatingUpgrades = true;
+        TowerManager.Instance.DisableTowerAfterSellingUpgrade(tower);
+      }
       return;
     }
 

--- a/Assets/Tower/Tower.cs
+++ b/Assets/Tower/Tower.cs
@@ -47,6 +47,7 @@ public abstract class Tower : MonoBehaviour {
     get { return data.enemies_hit; }
     set { data.enemies_hit = value; }
   }
+  public bool IsMutatingUpgrades { get; set; }
   public string Name {
     get { return data.name; }
     set { data.name = value; }


### PR DESCRIPTION
This adds a delay during which the tower is translucent and disabled whenever the player sells an upgrade.
While the tower is delayed this way, the player may sell upgrades with no penalties.

Included a small refactor of some of the delaying code.  Implemented a standard Coroutine that will delay the tower while its transparent and then run a continuation.

Tests Pass