### PR TITLE
Rework the 3rd acid upgrade of the Spitting Ant Tower

### DIFF
--- a/Assets/Enemy/Enemy.cs
+++ b/Assets/Enemy/Enemy.cs
@@ -606,8 +606,8 @@ public class Enemy : MonoBehaviour {
       if (venomSpreaders > 0) {
         var enemiesInRange = Targeting.GetAllValidEnemiesInRange(
             enemies: ObjectPool.Instance.GetActiveEnemies(),
-            towerPosition: transform.position,
-            towerRange: venomSpreadRange,
+            origin: transform.position,
+            range: venomSpreadRange,
             camoSight: true,
             antiAir: true);
 

--- a/Assets/Resources/Towers/MantisTower/MantisTower.cs
+++ b/Assets/Resources/Towers/MantisTower/MantisTower.cs
@@ -109,8 +109,8 @@ public class MantisTower : Tower {
     // Ensure that the target enemy is not among those reviewed for secondary damage.
     List<Enemy> potentialVictims = Targeting.GetAllValidEnemiesInRange(
         enemies: ObjectPool.Instance.GetActiveEnemies().Where(e => !e.Equals(Target)).ToHashSet(),
-        towerPosition: transform.position,
-        towerRange: Range,
+        origin: transform.position,
+        range: Range,
         camoSight: CamoSight,
         antiAir: AntiAir);
 

--- a/Assets/Resources/Towers/SpittingAntTower/Spitting Ant Tower.prefab
+++ b/Assets/Resources/Towers/SpittingAntTower/Spitting Ant Tower.prefab
@@ -55,23 +55,22 @@ MonoBehaviour:
     type: 0
     name: 
     icon_path: 
-    enemies_hit: 0
     acid_stacks: 0
+    bleed_stacks: 0
+    cost: 0
+    secondary_slow_targets: 0
+    venom_stacks: 0
     area_of_effect: 0
     armor_pierce: 0
     attack_speed: 0
-    bleed_stacks: 0
-    cost: 0
     damage: 0
     projectile_speed: 0
     range: 0
     secondary_slow_potency: 0
-    secondary_slow_targets: 0
     slow_duration: 0
     slow_power: 0
     stun_time: 0
     venom_power: 0
-    venom_stacks: 0
   targetingIndicator: {fileID: 601234435680318981}
   rangeIndicator: {fileID: 5129075295278649312}
   IsPreviewTower: 0
@@ -10310,7 +10309,7 @@ ParticleSystem:
     startSpeed:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 30
+      scalar: 15
       minScalar: 5
       maxCurve:
         serializedVersion: 2

--- a/Assets/Resources/Towers/SpittingAntTower/SpittingAntTower.cs
+++ b/Assets/Resources/Towers/SpittingAntTower/SpittingAntTower.cs
@@ -87,7 +87,6 @@ public class SpittingAntTower : Tower {
         if (enemy == target) continue;
         enemy.AddAcidStacks(AcidStacks / 2, AcidEnhancement);
       }
-      // TODO(emonzon): Trigger an acid splash.
       splashExplosion.transform.position = target.transform.position;
       splashExplosion.Play();
     }

--- a/Assets/Resources/Towers/SpittingAntTower/SpittingAntTower.cs
+++ b/Assets/Resources/Towers/SpittingAntTower/SpittingAntTower.cs
@@ -16,7 +16,7 @@ public class SpittingAntTower : Tower {
   public bool AcidicSynergy { get; private set; } = false;
   public bool VenomCorpseplosion { get; private set; } = false;
   public bool ContinuousAttack { get; private set; } = false;
-  public bool AcidBuildupBonus { get; private set; } = false;
+  public bool AoEAcid { get; private set; } = false;
   public bool AcidEnhancement { get; private set; } = false;
   public float AcidDecayDelay { get; private set; } = 10.0f;
   public float SplashExplosionRange {
@@ -46,8 +46,8 @@ public class SpittingAntTower : Tower {
       case SpecialAbility.SA_1_5_VENOM_CORPSEPLOSION:
         VenomCorpseplosion = true;
         break;
-      case SpecialAbility.SA_2_3_ACID_BUILDUP_BONUS:
-        AcidBuildupBonus = true;
+      case SpecialAbility.SA_2_3_AOE_ACID:
+        AoEAcid = true;
         break;
       case SpecialAbility.SA_2_5_DOT_ENHANCEMENT:
         AcidEnhancement = true;
@@ -76,11 +76,22 @@ public class SpittingAntTower : Tower {
     }
 
     // Acid DoT effects.
-    if (AcidBuildupBonus && target.Armor <= 0.0f) {
-      target.AddAcidStacks(acidStacks * 1.5f, AcidEnhancement);
-    } else {
-      target.AddAcidStacks(acidStacks, AcidEnhancement);
+    if (AoEAcid) {
+      var enemiesForAcid = Targeting.GetAllValidEnemiesInRange(
+        enemies: ObjectPool.Instance.GetActiveEnemies(),
+        origin: target.AimPoint,
+        range: AreaOfEffect,
+        camoSight: true,
+        antiAir: AntiAir);
+      foreach (Enemy enemy in enemiesForAcid) {
+        if (enemy == target) continue;
+        enemy.AddAcidStacks(AcidStacks / 2, AcidEnhancement);
+      }
+      // TODO(emonzon): Trigger an acid splash.
+      splashExplosion.transform.position = target.transform.position;
+      splashExplosion.Play();
     }
+    target.AddAcidStacks(acidStacks, AcidEnhancement);
 
     if (AcidEnhancement) {
       target.AddAdvancedAcidDecayDelay(this, AcidDecayDelay);

--- a/Assets/Resources/Towers/SpittingAntTower/SpittingAntTower.cs
+++ b/Assets/Resources/Towers/SpittingAntTower/SpittingAntTower.cs
@@ -78,11 +78,11 @@ public class SpittingAntTower : Tower {
     // Acid DoT effects.
     if (AoEAcid) {
       var enemiesForAcid = Targeting.GetAllValidEnemiesInRange(
-        enemies: ObjectPool.Instance.GetActiveEnemies(),
-        origin: target.AimPoint,
-        range: AreaOfEffect,
-        camoSight: true,
-        antiAir: AntiAir);
+          enemies: ObjectPool.Instance.GetActiveEnemies(),
+          origin: target.AimPoint,
+          range: AreaOfEffect,
+          camoSight: true,
+          antiAir: AntiAir);
       foreach (Enemy enemy in enemiesForAcid) {
         if (enemy == target) continue;
         enemy.AddAcidStacks(AcidStacks / 2, AcidEnhancement);

--- a/Assets/Tests/Generators/TowerDataGenerator.cs
+++ b/Assets/Tests/Generators/TowerDataGenerator.cs
@@ -52,7 +52,7 @@ public class TowerDataGenerator {
       new() {
         specialAbility = SpecialAbility.SA_1_3_ACIDIC_SYNERGY,
         name = "Acid Breakdown",
-        description = "When an enemy is more than halfway to an acid explosion, they take 50% bonus armor tear from this tower.",
+        description = "Within 30 radius of the tower, acid benefits from venom without consuming stacks.",
         upgradePath = 0,
         cost = 800,
       },
@@ -63,8 +63,8 @@ public class TowerDataGenerator {
         intAttributeModifiers = new AttributeModifier<int>[] {
           GetAttributeModifier(Stat.VENOM_STACKS, Mode.SET, 3),
         },
-        name = "Max Armor Tear",
-        description = "Increases armor tear to 5.",
+        name = "Max Venom",
+        description = "Attacks apply 3 stacks of 60% venom.",
         upgradePath = 0,
         cost = 10,
       },
@@ -102,9 +102,12 @@ public class TowerDataGenerator {
         cost = 150,
       },
       new() {
-        specialAbility = SpecialAbility.SA_2_3_ACID_BUILDUP_BONUS,
-        name = "Armorless Acid",
-        description = "If an enemy has no armor, they gain 50% more acid stacks from this tower.",
+        floatAttributeModifiers = new AttributeModifier<float>[] {
+          GetAttributeModifier(Stat.AREA_OF_EFFECT, Mode.SET, 5.0f)
+        },
+        specialAbility = SpecialAbility.SA_2_3_AOE_ACID,
+        name = "AoE Acid",
+        description = "Attacks inflict 1/2 (rounded down, min 1) acid stacks within 5 of the target.",
         upgradePath = 1,
         cost = 800,
       },
@@ -174,8 +177,8 @@ public class TowerDataGenerator {
     TowerData data = new() {
       type = TowerData.Type.SPITTING_ANT_TOWER,
       upgradeTreeData = new() {
-        first = "Armor Tear",
-        second = "Acid Power",
+        first = "Venom",
+        second = "Acid",
         third = "Utility",
         firstPathUpgrades = venomUpgrades,
         secondPathUpgrades = acidUpgrades,
@@ -188,7 +191,7 @@ public class TowerDataGenerator {
 
       name = "Spitting Ant Tower",
       icon_path = "Icons/test",
-      area_of_effect = 10,
+      area_of_effect = 0,
       armor_pierce = 0,
       attack_speed = 0.5f,
       cost = 100,

--- a/Assets/Tests/Tower/AssassinBugTowerTest.cs
+++ b/Assets/Tests/Tower/AssassinBugTowerTest.cs
@@ -20,6 +20,7 @@ public class AssassinBugTowerTest {
     GameStateManager.Instance = gsm;
 
     Time.captureDeltaTime = 1;
+    TowerManager.Instance = new TowerManager();
   }
 
   #region SpecialAbilityUpgradeTests

--- a/Assets/Tests/Tower/SpittingAntTowerTest.cs
+++ b/Assets/Tests/Tower/SpittingAntTowerTest.cs
@@ -22,8 +22,7 @@ public class SpittingAntTowerTest {
     spittingAntTower.SetProjectileHandler(projectileHandler);
     Time.captureDeltaTime = 1;
 
-    TowerManager towerManager = new TowerManager();
-    TowerManager.Instance = towerManager;
+    TowerManager.Instance = new TowerManager();
   }
 
   #region SpecialAbilityUpgradeTests

--- a/Assets/Tests/Tower/SpittingAntTowerTest.cs
+++ b/Assets/Tests/Tower/SpittingAntTowerTest.cs
@@ -43,15 +43,15 @@ public class SpittingAntTowerTest {
     spittingAntTower.SpecialAbilityUpgrade(TowerAbility.SpecialAbility.SA_1_5_VENOM_CORPSEPLOSION);
 
     Assert.That(true, Is.EqualTo(spittingAntTower.VenomCorpseplosion));
-    Assert.That(false, Is.EqualTo(spittingAntTower.AcidBuildupBonus));
+    Assert.That(false, Is.EqualTo(spittingAntTower.AoEAcid));
   }
 
   // Test setting DotSlow.
   [Test]
   public void SpecialAbilityUpgradeDotSlow() {
-    spittingAntTower.SpecialAbilityUpgrade(TowerAbility.SpecialAbility.SA_2_3_ACID_BUILDUP_BONUS);
+    spittingAntTower.SpecialAbilityUpgrade(TowerAbility.SpecialAbility.SA_2_3_AOE_ACID);
 
-    Assert.That(true, Is.EqualTo(spittingAntTower.AcidBuildupBonus));
+    Assert.That(true, Is.EqualTo(spittingAntTower.AoEAcid));
     Assert.That(false, Is.EqualTo(spittingAntTower.AcidEnhancement));
   }
 

--- a/Assets/Tower/Targeting.cs
+++ b/Assets/Tower/Targeting.cs
@@ -84,13 +84,13 @@ public class Targeting {
   // Find and return all enemies within the given tower's range and given the twoer's limitations.
   public static List<Enemy> GetAllValidEnemiesInRange(
       HashSet<Enemy> enemies,
-      Vector3 towerPosition,
-      float towerRange,
+      Vector3 origin,
+      float range,
       bool camoSight,
       bool antiAir) {
     return enemies
         .Where(e => e.enabled)
-        .Where(e => Vector2.Distance(towerPosition.DropY(), e.transform.position.DropY()) <= towerRange)
+        .Where(e => Vector2.Distance(origin.DropY(), e.transform.position.DropY()) <= range)
         .Where(e => !e.Flying || antiAir)
         .Where(e => !e.Camo || camoSight)
         .ToList();

--- a/Assets/Tower/TowerAbility.cs
+++ b/Assets/Tower/TowerAbility.cs
@@ -29,7 +29,7 @@ public struct TowerAbility {
     M_3_5_SHRIKE,  // Mantis Tower, Utility upgrade tree level 5.
     SA_1_3_ACIDIC_SYNERGY,  // Spitting Ant Tower, Armor Tear upgrade tree level 3.
     SA_1_5_VENOM_CORPSEPLOSION,  // Spitting Ant Tower, Armor Tear upgrade tree level 5.
-    SA_2_3_ACID_BUILDUP_BONUS,  // Spitting Ant Tower, Acid DoT upgrade tree level 3.
+    SA_2_3_AOE_ACID,  // Spitting Ant Tower, Acid DoT upgrade tree level 3.
     SA_2_5_DOT_ENHANCEMENT,  // Spitting Ant Tower, Acid DoT upgrade tree level 5.
     SA_3_3_ANTI_AIR,  // Spitting Ant Tower, Utility upgrade tree level 3.
     SA_3_5_CONSTANT_FIRE,  // Spitting Ant Tower, Utility upgrade tree level 5.

--- a/PlayModeTests.csproj
+++ b/PlayModeTests.csproj
@@ -8,8 +8,9 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>10.0.20506</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <RootNamespace></RootNamespace>
-    <ProjectGuid>{E0154A8A-4FFA-D768-7077-19D64B0D0043}</ProjectGuid>
+    <RootNamespace>
+    </RootNamespace>
+    <ProjectGuid>{6504BDF0-5EEB-747E-D2AA-FDC813127D30}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>PlayModeTests</AssemblyName>

--- a/data.towers
+++ b/data.towers
@@ -11,8 +11,8 @@
           <tooltipText>A ranged tower with moderate damage, armor tear, and acid DoTs.</tooltipText>
         </tooltip>
         <upgradeTreeData>
-          <first>Armor Tear</first>
-          <second>Acid Power</second>
+          <first>Venom</first>
+          <second>Acid</second>
           <third>Utility</third>
           <firstPathUpgrades>
             <TowerAbility>
@@ -70,7 +70,7 @@
             <TowerAbility>
               <specialAbility>SA_1_3_ACIDIC_SYNERGY</specialAbility>
               <name>Acid Breakdown</name>
-              <description>When an enemy is more than halfway to an acid explosion, they take 50% bonus armor tear from this tower.</description>
+              <description>Within 30 radius of the tower, acid benefits from venom without consuming stacks.</description>
               <upgradePath>0</upgradePath>
               <cost>800</cost>
             </TowerAbility>
@@ -90,8 +90,8 @@
                   <mod>3</mod>
                 </AttributeModifierOfInt32>
               </intAttributeModifiers>
-              <name>Max Armor Tear</name>
-              <description>Increases armor tear to 5.</description>
+              <name>Max Venom</name>
+              <description>Attacks apply 3 stacks of 60% venom.</description>
               <upgradePath>0</upgradePath>
               <cost>10</cost>
             </TowerAbility>
@@ -147,9 +147,16 @@
               <cost>150</cost>
             </TowerAbility>
             <TowerAbility>
-              <specialAbility>SA_2_3_ACID_BUILDUP_BONUS</specialAbility>
-              <name>Armorless Acid</name>
-              <description>If an enemy has no armor, they gain 50% more acid stacks from this tower.</description>
+              <specialAbility>SA_2_3_AOE_ACID</specialAbility>
+              <floatAttributeModifiers>
+                <AttributeModifierOfSingle>
+                  <attribute>AREA_OF_EFFECT</attribute>
+                  <mode>SET</mode>
+                  <mod>5</mod>
+                </AttributeModifierOfSingle>
+              </floatAttributeModifiers>
+              <name>AoE Acid</name>
+              <description>Attacks inflict 1/2 (rounded down, min 1) acid stacks within 5 of the target.</description>
               <upgradePath>1</upgradePath>
               <cost>800</cost>
             </TowerAbility>
@@ -251,7 +258,7 @@
         <cost>100</cost>
         <secondary_slow_targets>0</secondary_slow_targets>
         <venom_stacks>0</venom_stacks>
-        <area_of_effect>10</area_of_effect>
+        <area_of_effect>0</area_of_effect>
         <armor_pierce>0</armor_pierce>
         <attack_speed>0.5</attack_speed>
         <damage>10</damage>


### PR DESCRIPTION
This PR reworks the third upgrade of the Spitting Ant Tower from being dependent on enemy armor being reduced to 0 and to projectiles triggering an AoE application of acid stacks.

All tests are passing