### PR TITLE
Fix Stubborn Targeting Bug

### DIFF
--- a/Assets/Resources/Towers/MantisTower/MantisTower.cs
+++ b/Assets/Resources/Towers/MantisTower/MantisTower.cs
@@ -172,12 +172,12 @@ public class MantisTower : Tower {
       if (IsDazzled()) continue;
 
       Target = targeting.FindTarget(
-      oldTarget: Target,
-      enemies: ObjectPool.Instance.GetActiveEnemies(),
-      towerPosition: transform.position,
-      towerRange: Range,
-      camoSight: CamoSight,
-      antiAir: AntiAir);
+          oldTarget: Target,
+          enemies: ObjectPool.Instance.GetActiveEnemies(),
+          towerPosition: transform.position,
+          towerRange: Range,
+          camoSight: CamoSight,
+          antiAir: AntiAir);
 
       if (Target != null) {
         Stab();

--- a/Assets/Resources/Towers/SpittingAntTower/SpittingAntTower.cs
+++ b/Assets/Resources/Towers/SpittingAntTower/SpittingAntTower.cs
@@ -110,12 +110,12 @@ public class SpittingAntTower : Tower {
     }
 
     Target = targeting.FindTarget(
-      oldTarget: Target,
-      enemies: ObjectPool.Instance.GetActiveEnemies(),
-      towerPosition: transform.position,
-      towerRange: Range,
-      camoSight: CamoSight,
-      antiAir: AntiAir);
+        oldTarget: Target,
+        enemies: ObjectPool.Instance.GetActiveEnemies(),
+        towerPosition: transform.position,
+        towerRange: Range,
+        camoSight: CamoSight,
+        antiAir: AntiAir);
     // If there is no target, stop firing.
     if (Target == null) {
       beam.enabled = false;

--- a/Assets/Resources/Towers/WebShootingSpiderTower/WebShootingSpiderTower.cs
+++ b/Assets/Resources/Towers/WebShootingSpiderTower/WebShootingSpiderTower.cs
@@ -94,12 +94,12 @@ public class WebShootingSpiderTower : Tower {
 
   protected override void TowerUpdate() {
     Target = targeting.FindTarget(
-      oldTarget: Target,
-      enemies: ObjectPool.Instance.GetActiveEnemies(),
-      towerPosition: transform.position,
-      towerRange: Range,
-      camoSight: CamoSight,
-      antiAir: AntiAir);
+        oldTarget: Target,
+        enemies: ObjectPool.Instance.GetActiveEnemies(),
+        towerPosition: transform.position,
+        towerRange: Range,
+        camoSight: CamoSight,
+        antiAir: AntiAir);
     if (Target == null) {
       firing = false;
       // TODO: Have the tower go back to an 'idle' animation or neutral pose.

--- a/Assets/Scenes/Dev/Initial_Balance_Testing.unity
+++ b/Assets/Scenes/Dev/Initial_Balance_Testing.unity
@@ -211,7 +211,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2291719801530528003, guid: da18247df7c3153459dda46fb9cfb8f0, type: 3}
       propertyPath: data.size
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2291719801530528003, guid: da18247df7c3153459dda46fb9cfb8f0, type: 3}
       propertyPath: data.type
@@ -219,7 +219,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2291719801530528003, guid: da18247df7c3153459dda46fb9cfb8f0, type: 3}
       propertyPath: data.maxHP
-      value: 65
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 2291719801530528003, guid: da18247df7c3153459dda46fb9cfb8f0, type: 3}
       propertyPath: data.speed

--- a/Assets/Tower/Targeting.cs
+++ b/Assets/Tower/Targeting.cs
@@ -61,7 +61,7 @@ public class Targeting {
     // Ensure the old target is within range of the tower.
     if (behavior == Behavior.STUBBORN
         && oldTarget != null
-        && oldTarget.enabled
+        && oldTarget.isActiveAndEnabled
         && (Vector2.Distance(towerPosition.DropY(), oldTarget.transform.position.DropY()) <= towerRange)
         && (!oldTarget.Camo || camoSight)
         && (!oldTarget.Flying || antiAir)) {

--- a/PlayModeTests.csproj
+++ b/PlayModeTests.csproj
@@ -8,8 +8,9 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>10.0.20506</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <RootNamespace></RootNamespace>
-    <ProjectGuid>{E0154A8A-4FFA-D768-7077-19D64B0D0043}</ProjectGuid>
+    <RootNamespace>
+    </RootNamespace>
+    <ProjectGuid>{6504BDF0-5EEB-747E-D2AA-FDC813127D30}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>PlayModeTests</AssemblyName>


### PR DESCRIPTION
This PR includes two main points:
1. Fix the stubborn targeting bug. It occurred when a tower with stubborn behavior killed an enemy (or an enemy was killed while being targeted by a tower with stubborn). The fix was to be more exclusive about target testing when checking the Stubborn predicate.
2. Correct some code styling.

All tests pass